### PR TITLE
Rename var forem_gcp_project to forem_gcp_project_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,13 +130,13 @@ forem_gcp_region: us-central1
 forem_gcp_zone: a
 forem_gcp_machine_type: e2-small
 forem_gcp_disk_size: 100
-forem_gcp_project: forem-selfhost
+forem_gcp_project_id: forem-selfhost-12345
 ```
 
 - `forem_gcp_region` + `forem_gcp_zone`: the Google Cloud region and zone that is used to setup your Forem server. The default region is `us-central1` in zone `a` which is in Council Bluffs, Iowa, USA
 - `forem_gcp_machine_type`: the GCP machine type. A recommended type is `e2-small`, with 2 shared CPUs and 2GB of RAM
 - `forem_gcp_disk_size`: the amount of disk space (in GB)
-- `forem_gcp_project`: your GCP project name
+- `forem_gcp_project_id`: your GCP project ID
 
 #### Setup
 1) Install the Google Cloud collection `ansible-galaxy collection install google.cloud` or install it via `ansible-galaxy collection install -r requirements.yml`

--- a/inventory/providers/gcp/gcp.yml
+++ b/inventory/providers/gcp/gcp.yml
@@ -1,6 +1,6 @@
 plugin: gcp_compute
 projects:
- - forem-selfhost # Replace this with your GCP project name
+ - forem-selfhost-12345 # Replace this with your GCP project ID
 filters:
   - 'name = forem*'
 hostnames: ['public_ip', 'name']

--- a/playbooks/providers/gcp.yml
+++ b/playbooks/providers/gcp.yml
@@ -15,7 +15,7 @@
     forem_gcp_zone: a
     forem_gcp_machine_type: e2-small
     forem_gcp_disk_size: 100
-    forem_gcp_project: forem-selfhost
+    forem_gcp_project_id: forem-selfhost-12345
     forem_gcp_cred_kind: serviceaccount
     forem_gcp_cred_file: "~/.gcp/forem.json"
     butane_cleanup: true
@@ -42,7 +42,7 @@
       size_gb: "{{ forem_gcp_disk_size }}"
       source_image: "projects/fedora-coreos-cloud/global/images/family/fedora-coreos-{{ fcos_stream }}"
       zone: "{{forem_gcp_region }}-{{ forem_gcp_zone }}"
-      project: "{{ forem_gcp_project }}"
+      project: "{{ forem_gcp_project_id }}"
       auth_kind: "{{ forem_gcp_cred_kind }}"
       service_account_file: "{{ forem_gcp_cred_file }}"
       state: present
@@ -57,7 +57,7 @@
         - '22'
       source_ranges:
         - "{{ local_wan_ip_address }}/32"
-      project: "{{ forem_gcp_project }}"
+      project: "{{ forem_gcp_project_id }}"
       auth_kind: "{{ forem_gcp_cred_kind }}"
       service_account_file: "{{ forem_gcp_cred_file }}"
       state: present
@@ -72,7 +72,7 @@
         - '443'
       source_ranges:
         - "0.0.0.0/0"
-      project: "{{ forem_gcp_project }}"
+      project: "{{ forem_gcp_project_id }}"
       auth_kind: "{{ forem_gcp_cred_kind }}"
       service_account_file: "{{ forem_gcp_cred_file }}"
       state: present
@@ -81,7 +81,7 @@
     gcp_compute_address:
       name: "forem-{{ app_domain |replace('.', '-') }}"
       region: "{{ forem_gcp_region }}"
-      project: "{{ forem_gcp_project }}"
+      project: "{{ forem_gcp_project_id }}"
       auth_kind: "{{ forem_gcp_cred_kind }}"
       service_account_file: "{{ forem_gcp_cred_file }}"
       state: present
@@ -108,7 +108,7 @@
       labels:
         app: forem
       zone: "{{forem_gcp_region }}-{{ forem_gcp_zone }}"
-      project: "{{ forem_gcp_project }}"
+      project: "{{ forem_gcp_project_id }}"
       auth_kind: "{{ forem_gcp_cred_kind }}"
       service_account_file: "{{ forem_gcp_cred_file }}"
       metadata:


### PR DESCRIPTION
Rename `forem_gcp_project` to `forem_gcp_project_id`, as it's specifically the GCP Project ID string that is used by the Ansible modules, not the Project Name.