### PR TITLE
Add link and explicit wording about generating secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ _Note: Following this quick start guide with the cloud provider of your choice w
         - forem_domain_name (A domain name that you own and set A records on at your DNS provider)
         - forem_subdomain_name (defaults to www)
         - forem_server_hostname (defaults to host)
-    - Generate and save Ansible Inventory secrets using [ansible-vault encrypt_string](https://docs.ansible.com/ansible/latest/user_guide/vault.html#encrypting-individual-variables-with-ansible-vault) (see Required Ansible Vault secret variables in setup.yml):
+    - Generate and Ansible Inventory secrets using [`ansible-vault encrypt_string`](https://docs.ansible.com/ansible/latest/user_guide/vault.html#encrypting-individual-variables-with-ansible-vault) for the variables below. See ["Required Ansible Vault secret variables" in the example setup.yml](https://github.com/forem/selfhost/blob/main/inventory/example/setup.yml#L64), which contains the required commands to generate each variable's value:
         - vault_secret_key_base
         - vault_imgproxy_key
         - vault_imgproxy_salt

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ _Note: Following this quick start guide with the cloud provider of your choice w
         - forem_domain_name (A domain name that you own and set A records on at your DNS provider)
         - forem_subdomain_name (defaults to www)
         - forem_server_hostname (defaults to host)
-    - Generate and Ansible Inventory secrets using [`ansible-vault encrypt_string`](https://docs.ansible.com/ansible/latest/user_guide/vault.html#encrypting-individual-variables-with-ansible-vault) for the variables below. See ["Required Ansible Vault secret variables" in the example setup.yml](https://github.com/forem/selfhost/blob/main/inventory/example/setup.yml#L64), which contains the required commands to generate each variable's value:
+    - Generate and save Ansible Inventory secrets using [`ansible-vault encrypt_string`](https://docs.ansible.com/ansible/latest/user_guide/vault.html#encrypting-individual-variables-with-ansible-vault) for the variables below. See ["Required Ansible Vault secret variables" in the example setup.yml](https://github.com/forem/selfhost/blob/main/inventory/example/setup.yml#L64), which contains the required commands to generate each variable's value:
         - vault_secret_key_base
         - vault_imgproxy_key
         - vault_imgproxy_salt


### PR DESCRIPTION
A creator had a question about this step, which we discussed internally: https://forem-team.slack.com/archives/C023Z19ELNB/p1626275810177800

This adds a direct link to the example inventory where we provide the explicit commands that can be used to generate vaulted Ansible variables.