### PR TITLE
Use AWS to retrieve IPv4 IP

### DIFF
--- a/roles/preflight/tasks/main.yml
+++ b/roles/preflight/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
 # tasks file for preflight
 
-- name: Fetch public WAN IP json
+- name: Fetch public WAN IPv4 address json
   ansible.builtin.uri:
-    url: https://icanhazip.com/
+    url: https://checkip.amazonaws.com/
     return_content: yes
   changed_when: no
   register: local_wan_json


### PR DESCRIPTION
Closes #7 

The `checkip.amazonaws.com` domain should only return an IPv4 public WAN address:

```
~ $ curl -4 "https://checkip.amazonaws.com/"
75.XXX.XXX.XXX
~ $ curl -6 "https://checkip.amazonaws.com/"
curl: (6) Could not resolve host: checkip.amazonaws.com
```