### PR TITLE
akhil-naidu/README_typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is a repo for setting up a free, self-managed install of [Forem](https://gi
 
 **If a Self-Hosted Forem is not right for you, we offer a fully-managed, enterprise solution called Forem Cloud; no technical setup required. For more information, [please contact us via this form](https://formkeep.com/p/cfa67316d1c12d23ecb3c08b359f944b).**
 
-For those that want to DIY beyond the scope of this repo, you can use the systemd units in the [Butane template](https://github.com/forem/selfhost-devel/blob/main/playbooks/templates/forem.yml.j2) as an example of how to run Forem without Fedora CoreOS on a Linux distribution that supports systemd, or customize that template to fit your needs or create a bootable Ignition configuration to consume on bare metal or in a custom VM.
+For those that want to DIY beyond the scope of this repo, you can use the systemd units in the [Butane template](https://github.com/forem/selfhost/blob/main/playbooks/templates/forem.yml.j2) as an example of how to run Forem without Fedora CoreOS on a Linux distribution that supports systemd, or customize that template to fit your needs or create a bootable Ignition configuration to consume on bare metal or in a custom VM.
 
 The goal of this project is to provide you with the choice, freedom, and cost-effectiveness to host your own Forem community as you see fit.
 
@@ -68,7 +68,7 @@ _Note: Following this quick start guide with the cloud provider of your choice w
     - [Google Cloud](https://github.com/forem/selfhost#provision-2)
 10) Once your Forem VM is set up with your chosen cloud provider, you will need to point DNS at the IP address that is output at the end of the provider playbook.
 11) Once DNS is pointed at your Forem VM, you will need to restart the Forem Traefik service (`sudo systemctl restart forem-traefik.service`) [via SSH on your Forem server](https://github.com/forem/selfhost#ssh-examples) to generate a TLS cert.
-12) Go to your Forem domain name and create your first account. Please see the Forem Admin documentation located [here](https://forem-admin.netlify.app/) for more information on setting up your Forem.
+12) Go to your Forem domain name and create your first account. Please see the Forem Admin documentation located [here](https://admin.forem.com/) for more information on setting up your Forem.
 
 ----
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ We can't wait to see the community you selfhost with Forem!
 
 - Git
 - [Python 3.x](https://www.python.org/downloads/) and pip3
-    - macOS: `brew install python3` **Note: this will likely use Python 3 at `/usr/local/bin/python3`, _not_ `/usr/bin/python3`, requiring that you set `ansible_python_interpreter` to `/usr/local/bin/python` in inventory or via extra vars (eg `-e ansible_python_interpreter=/usr/local/bin/python`)**
+    - macOS: `brew install python3` 
+    > **Note**: This will likely use **Python 3** at `/usr/local/bin/python3`, _not_ `/usr/bin/python3`, requiring that you set `ansible_python_interpreter` to `/usr/local/bin/python` in inventory or via extra vars (eg `-e ansible_python_interpreter=/usr/local/bin/python`)
 - [Ansible](https://docs.ansible.com/ansible/latest/installation_guide/index.html): `ansible-core` 2.11 or greater (provided by Ansible 4.0.0)
 - [Butane](https://github.com/coreos/butane/blob/master/docs/getting-started.md#getting-butane)
     - Mac OS: `brew install butane`

--- a/playbooks/providers/aws.yml
+++ b/playbooks/providers/aws.yml
@@ -220,4 +220,4 @@
       - "Please add an A entry for {{ app_domain }} that points to {{ forem_ec2_instance.tagged_instances | map(attribute='public_ip') | list | first }}"
       - "Example:"
       - "    {{ app_domain }} IN A {{ forem_ec2_instance.tagged_instances | map(attribute='public_ip') | list | first }}"
-      - "Once you have DNS resolving to this EC2 instance please read the Forem Admin Docs: https://forem-admin.netlify.app/"
+      - "Once you have DNS resolving to this EC2 instance please read the Forem Admin Docs: https://admin.forem.com/"

--- a/playbooks/providers/digitalocean.yml
+++ b/playbooks/providers/digitalocean.yml
@@ -245,6 +245,6 @@
         - "Example:"
         - "    {{ app_domain }} IN A {{ forem_fcos_droplet_info.data.ip_address }}"
         - "Or use these DNS nameservers: {{ dns_record_response.json | community.general.json_query(forem_domain_nameserver_query)| list }} for {{ forem_domain_name }}"
-        - "Once you have DNS resolving to this DigitalOcean instance please read the Forem Admin Docs: https://forem-admin.netlify.app/"
+        - "Once you have DNS resolving to this DigitalOcean instance please read the Forem Admin Docs: https://admin.forem.com/"
     vars:
       forem_domain_nameserver_query: "domain_records[?type=='NS'].data"

--- a/playbooks/providers/gcp.yml
+++ b/playbooks/providers/gcp.yml
@@ -123,4 +123,4 @@
       - "Please add an A entry for {{ app_domain }} that points to {{ forem_gcp_address.address }}"
       - "Example:"
       - "    {{ app_domain }} IN A {{ forem_gcp_address.address }}"
-      - "Once you have DNS resolving to this Google Compute VM please read the Forem Admin Docs: https://forem-admin.netlify.app/"
+      - "Once you have DNS resolving to this Google Compute VM please read the Forem Admin Docs: https://admin.forem.com/"


### PR DESCRIPTION
### Edits in the PR
- Butane template was redirecting to `selfhost-devel` repository, which was empty -> Remapped to `selfhost` repository
- Admins docs were being referred to Netlify domain(https://forem-admin.netlify.app/) -> Remapped to Forem Domain(https://admin.forem.com/)
- Reduced the length of the bullet point and highlighted the Note using a quotation tag.

### A point to Mention
At the end of every successful Forem installation, we have a deployment success message, in which the Admin Docs are also referred to the Netlify domain, rather than the Forem domain.