### PR TITLE
Add forem-imgproxy.service to Wants on forem-pod.service

### DIFF
--- a/playbooks/templates/forem.yml.j2
+++ b/playbooks/templates/forem.yml.j2
@@ -809,7 +809,7 @@ systemd:
       Description=Forem pod service
       Wants=network.target
       After=network-online.target forem-container.service
-      Wants=forem-postgresql.service forem-redis.service forem.service forem-traefik.service
+      Wants=forem-postgresql.service forem-redis.service forem-imgproxy.service forem.service forem-traefik.service
       Before=forem-postgresql.service forem-redis.service forem-openresty.service forem.service
 
       [Service]


### PR DESCRIPTION
The `forem-pod.service` should want the `forem-imgproxy.service` before it can start. Otherwise without it, we will have busted images on a Forem.