### PR TITLE
Add google.cloud to requirements.yml

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -4,3 +4,4 @@ collections:
     version: 1.0.0
   - name: amazon.aws
   - name: community.aws
+  - name: google.cloud


### PR DESCRIPTION
We forgot to add in `google.cloud` to the `requirements.yml` file. Woops!