### PR TITLE
Add referrer policy option

### DIFF
--- a/inventory/example/setup.yml
+++ b/inventory/example/setup.yml
@@ -33,6 +33,10 @@ all:
           default_email: REPLACEME
           forem_subdomain_name: www # can be subdomain, i.e. "community" in community.mainwebsite.com
           forem_server_hostname: host # You may change to something else if you choose (i.e. server, srv, etc)
+
+          # CHANGE_OPTIONAL - strict-origin-when-cross-origin enables embedded youtube video playback
+          referrer_policy: "same-origin"
+          # referrer_policy: "strict-origin-when-cross-origin"
           app_domain: "{{ forem_subdomain_name }}.{{ forem_domain_name }}"
           secret_key_base: "{{ vault_secret_key_base }}"
           session_key: _FOREMSELFHOST_Session

--- a/playbooks/templates/forem.yml.j2
+++ b/playbooks/templates/forem.yml.j2
@@ -690,8 +690,8 @@ storage:
             CustomFrameOptionsValue = "SAMEORIGIN"
             ForceSTSHeader = true
             FrameDeny = true
-	    # set ReferrerPolicy to "strict-origin-when-cross-origin" if youtube embedding is broken
-            ReferrerPolicy = "same-origin"
+	    # ReferrerPolicy configured in the setup.yml during provisioning
+            ReferrerPolicy = {{ referrer_policy }}
             SSLRedirect = true
             stsIncludeSubdomains = true
             stsPreload = true

--- a/playbooks/templates/forem.yml.j2
+++ b/playbooks/templates/forem.yml.j2
@@ -690,7 +690,7 @@ storage:
             CustomFrameOptionsValue = "SAMEORIGIN"
             ForceSTSHeader = true
             FrameDeny = true
-	    # ReferrerPolicy configured in the setup.yml during provisioning
+            # ReferrerPolicy configured in the setup.yml during provisioning
             ReferrerPolicy = {{ referrer_policy }}
             SSLRedirect = true
             stsIncludeSubdomains = true

--- a/playbooks/templates/forem.yml.j2
+++ b/playbooks/templates/forem.yml.j2
@@ -690,6 +690,7 @@ storage:
             CustomFrameOptionsValue = "SAMEORIGIN"
             ForceSTSHeader = true
             FrameDeny = true
+	    # set ReferrerPolicy to "strict-origin-when-cross-origin" if youtube embedding is broken
             ReferrerPolicy = "same-origin"
             SSLRedirect = true
             stsIncludeSubdomains = true


### PR DESCRIPTION
I suspect youtube embedded video playback is not working if referrer policy is set to "same-origin". 

Add a configuration variable to support relaxing this during setup.

Add a hint in setup.yml that you might change this, and a note in the generated toml file that this came from a variable upstream.
