### PR TITLE
Add referrer policy option again

### DIFF
--- a/inventory/example/setup.yml
+++ b/inventory/example/setup.yml
@@ -33,6 +33,10 @@ all:
           default_email: REPLACEME
           forem_subdomain_name: www # can be subdomain, i.e. "community" in community.mainwebsite.com
           forem_server_hostname: host # You may change to something else if you choose (i.e. server, srv, etc)
+
+          # CHANGE_OPTIONAL - strict-origin-when-cross-origin enables embedded youtube video playback
+          referrer_policy: "same-origin"
+          # referrer_policy: "strict-origin-when-cross-origin"
           app_domain: "{{ forem_subdomain_name }}.{{ forem_domain_name }}"
           secret_key_base: "{{ vault_secret_key_base }}"
           session_key: _FOREMSELFHOST_Session

--- a/playbooks/templates/forem.yml.j2
+++ b/playbooks/templates/forem.yml.j2
@@ -690,7 +690,8 @@ storage:
             CustomFrameOptionsValue = "SAMEORIGIN"
             ForceSTSHeader = true
             FrameDeny = true
-            ReferrerPolicy = "same-origin"
+            # ReferrerPolicy configured in the setup.yml during provisioning
+            ReferrerPolicy = {{ referrer_policy }}
             SSLRedirect = true
             stsIncludeSubdomains = true
             stsPreload = true


### PR DESCRIPTION
Reverts forem/selfhost#38

One thing to note - after this change a required variable _must_ be added to the inventory/forem/setup.yml which is only present in the inventory/example/setup.yml  

This will impact users who (1) already cloned the repo and copied/customized the setup.yml file (2) subsequently pull the current git head