### PR TITLE
Surround value with quotes

### DIFF
--- a/playbooks/templates/forem.yml.j2
+++ b/playbooks/templates/forem.yml.j2
@@ -691,7 +691,7 @@ storage:
             ForceSTSHeader = true
             FrameDeny = true
             # ReferrerPolicy configured in the setup.yml during provisioning
-            ReferrerPolicy = {{ referrer_policy }}
+            ReferrerPolicy = "{{ referrer_policy }}"
             SSLRedirect = true
             stsIncludeSubdomains = true
             stsPreload = true


### PR DESCRIPTION
Fixes an error seen when starting traefik due to an unquoted string

```
*file.Provider: Near line 22 (last key parsed 'http.middlewares.security.headers.ReferrerPolicy'): expected value but found \"same\" instead"
```


On main - building in qemu - the resulting /opt/forem/configs/traefik/dynamic.toml includes an unquoted string for referrer policy:

    ReferrerPolicy = same-origin

On this branch the generated toml file quotes that value


    ReferrerPolicy = "same-origin"