### PR TITLE
Add second SSH example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,12 @@ All of these examples need to be run via SSH on the Fedora CoreOS server as the 
 ssh core@<SERVER IP ADDRESS>
 ```
 
+If your key doesn't have a default name like `id_dsa`, `id_ecdsa`, `id_rsa`, etc. you must specify it with the `-i identity_file` option. For example, this is the command you need to run for a key named `forem`:
+
+```
+ssh -i ~/.ssh/forem core@<SERVER IP ADDRESS>
+```
+
 ### foremctl
 
 We have a helper script (Forem Control) called `foremctl`. It is used to control your Forem via CLI.


### PR DESCRIPTION
This PR adds an example for using the `-i identify_file` option with `ssh`.  In step 5 of the installation instructions, we tell people to generate a key in `${HOME}/.ssh/forem` but the examples didn't show how to use such a key. This tripped up Rajat when he attempted a selfhost install and we resolved this on a call, so I figured it's probably better to add it to the README.