### PR TITLE
Add comment about ansible-vault, and update the readme link

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Once the script finished running, continue from step 4. of the manual installati
         - forem_domain_name (A domain name that you own and set A records on at your DNS provider)
         - forem_subdomain_name (defaults to www)
         - forem_server_hostname (defaults to host)
-    - If you used the setup script you can use the previously generated inventory secrets here. Otherwise, you have to use  [`ansible-vault encrypt_string`](https://docs.ansible.com/ansible/latest/user_guide/vault.html#encrypting-individual-variables-with-ansible-vault) to create the secrets listed below. See ["Required Ansible Vault secret variables" in the example setup.yml](https://github.com/forem/selfhost/blob/main/inventory/example/setup.yml#L64), which contains the required commands to generate each variable's value:
+    - If you used the setup script you can use the previously generated inventory secrets here. Otherwise, you have to use  [`ansible-vault encrypt_string`](https://docs.ansible.com/ansible/latest/user_guide/vault.html#encrypting-individual-variables-with-ansible-vault) to create the secrets listed below. See ["Required Ansible Vault secret variables" in the example setup.yml](https://github.com/forem/selfhost/blob/main/inventory/example/setup.yml#L67), which contains the required commands to generate each variable's value:
         - vault_secret_key_base
         - vault_imgproxy_key
         - vault_imgproxy_salt

--- a/inventory/example/setup.yml
+++ b/inventory/example/setup.yml
@@ -66,6 +66,9 @@ all:
 
           # Required Ansible Vault secret variables
           # Use the following example commands below in a terminal to generate the required variables with Ansible Vault encrypt_string
+          # These commands should be run in the selfhost directory, since the
+          # ansible.cfg identifies the vault password which will be used to decrypt
+          # if ansible-vault prompts for a password, something is not right
           # See this URL to learn more about ansible-vault:
           # https://docs.ansible.com/ansible/latest/user_guide/vault.html#encrypting-individual-variables-with-ansible-vault
 


### PR DESCRIPTION
Readme link was a few lines too early (probably an insertion further
up), change line 64 to line 67 so the link points to the right
location.

I ran into a confusing situation running what looked like normal shell
commands to pass random data to ansible-vault, where a password was
prompted for, and decrypting the vault secrets in the yaml file
failed. The hidden context was that the commands must run in the selfhost 
directory for the vault encryption to use the same password as the playbook.

Add a safeguard note that you should be in the selfhost
directory (where the ansible.cfg file is present) before running the
shell commands, and a hint that being prompted for a password is an
indication that something went wrong.