### PR TITLE
terraform/env: Remove unused pusher_* references.

### DIFF
--- a/inventory/example/setup.yml
+++ b/inventory/example/setup.yml
@@ -51,12 +51,6 @@ all:
           postgres_user: forem_production
           postgres_password: "{{ vault_forem_postgres_password }}"
           postgres_host: localhost
-          pusher_app_id: "{{ vault_pusher_app_id }}"
-          pusher_beams_id: "{{ vault_pusher_beams_id }}"
-          pusher_beams_key: "{{ vault_pusher_beams_key }}"
-          pusher_cluster: us2
-          pusher_key: "{{ vault_pusher_key }}"
-          pusher_secret: "{{ vault_pusher_secret }}"
           recaptcha_secret: "{{ vault_recaptcha_secret }}"
           recaptcha_site: "{{ vault_recaptcha_site }}"
           sendgrid_api_key: "{{ vault_sendgrid_api_key }}"
@@ -145,11 +139,6 @@ all:
           vault_honeybadger_api_key:
           vault_honeybadger_js_api_key:
           vault_honeycomb_api_key:
-          vault_pusher_app_id:
-          vault_pusher_beams_id:
-          vault_pusher_beams_key:
-          vault_pusher_key:
-          vault_pusher_secret:
           vault_recaptcha_secret:
           vault_recaptcha_site:
           vault_sendgrid_api_key:

--- a/inventory/providers/qemu/static.yml
+++ b/inventory/providers/qemu/static.yml
@@ -44,12 +44,6 @@ all:
           postgres_user: forem_production
           postgres_password: "{{ vault_forem_postgres_password }}"
           postgres_host: localhost
-          pusher_app_id: "{{ vault_pusher_app_id }}"
-          pusher_beams_id: "{{ vault_pusher_beams_id }}"
-          pusher_beams_key: "{{ vault_pusher_beams_key }}"
-          pusher_cluster: us2
-          pusher_key: "{{ vault_pusher_key }}"
-          pusher_secret: "{{ vault_pusher_secret }}"
           recaptcha_secret: "{{ vault_recaptcha_secret }}"
           recaptcha_site: "{{ vault_recaptcha_site }}"
           sendgrid_api_key: "{{ vault_sendgrid_api_key }}"
@@ -75,11 +69,6 @@ all:
           vault_honeybadger_api_key:
           vault_honeybadger_js_api_key:
           vault_honeycomb_api_key:
-          vault_pusher_app_id:
-          vault_pusher_beams_id:
-          vault_pusher_beams_key:
-          vault_pusher_key:
-          vault_pusher_secret:
           vault_recaptcha_secret:
           vault_recaptcha_site:
           vault_sendgrid_api_key:

--- a/playbooks/templates/forem.yml.j2
+++ b/playbooks/templates/forem.yml.j2
@@ -518,12 +518,6 @@ storage:
         HONEYBADGER_API_KEY={{ honeybadger_api_key }}
         HONEYBADGER_JS_API_KEY={{ honeybadger_js_api_key }}
         HONEYCOMB_API_KEY={{ honeycomb_api_key }}
-        PUSHER_APP_ID={{ pusher_app_id }}
-        PUSHER_BEAMS_ID={{ pusher_beams_id }}
-        PUSHER_BEAMS_KEY={{ pusher_beams_key }}
-        PUSHER_CLUSTER={{ pusher_cluster }}
-        PUSHER_KEY={{ pusher_key }}
-        PUSHER_SECRET={{ pusher_secret }}
         RECAPTCHA_SECRET={{ recaptcha_secret }}
         RECAPTCHA_SITE={{ recaptcha_site }}
         SENDGRID_API_KEY={{ sendgrid_api_key }}


### PR DESCRIPTION
Refs an internal infra issue where we wanted to clean up env vars that are no longer ref'd anywhere in forem/forem (or within any Forem Cloud infra).